### PR TITLE
Reset G.zip64 for empty extra filed

### DIFF
--- a/fileio.c
+++ b/fileio.c
@@ -2030,8 +2030,16 @@ int do_string(__G__ length, option)   /* return PK-type error code */
     length of the string:  if zero, we're already done.
   ---------------------------------------------------------------------------*/
 
-    if (!length)
+    if (!length) {
+        if (option == EXTRA_FIELD) {
+            /*
+             * With this shortcut, we are not calling getZip64Data, but we need
+             * to call it to at least reset G.zip64.
+             */
+            getZip64Data(__G__ NULL, 0);
+        }
         return PK_COOL;
+    }
 
     switch (option) {
 


### PR DESCRIPTION
When zip file contains a file with central directory header without
an extra filed (and thus the data descriptor is not in ZIP64 format),
`G.zip64` flag is not reset.

It can cause problems for zip files with mix of files larger and smaller
than 4GB, created by compressors, which add extra fields only for files
larger than 4GB (like Java).

This change resets `G.zip64` (by calling `getZip64Data` with empty
buffer) in case of an empty extra field in central directory header.

Following sequence of commands reproduces the problem:

```
dd if=/dev/zero of=file_larger_than_4g bs=1024 count=4194305
dd if=/dev/zero of=file_smaller_than_4g bs=1024 count=1

cat > TestZip.java <<EOF
import java.util.zip.ZipOutputStream;
import java.util.zip.ZipEntry;
import java.io.FileInputStream;
import java.io.FileOutputStream;

class TestZip {
    private static void addFileToZip(ZipOutputStream zos, String name) throws Exception {
        byte[] buffer = new byte[2048];

        FileInputStream fis = new FileInputStream(name);
        zos.putNextEntry(new ZipEntry(name));
        int length;
        while ((length = fis.read(buffer)) > 0) {
            zos.write(buffer, 0, length);
        }
    }

    public static void main(String args[]) throws Exception {
        ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("test_zip.zip"));
        addFileToZip(zos, "file_larger_than_4g");
        addFileToZip(zos, "file_smaller_than_4g");
        zos.close();
    }
}
EOF

javac TestZip.java
java TestZip

./unzip -t test_zip.zip file_smaller_than_4g
```

Without the fix:
```
[nix-shell:~/src/unzip]$ ./unzip -t test_zip.zip file_smaller_than_4g
Archive:  test_zip.zip
    testing: file_smaller_than_4g     OK
error: invalid zip file with overlapped components (possible zip bomb)
```

After the fix:
```
[nix-shell:~/src/unzip]$ ./unzip -t test_zip.zip file_smaller_than_4g
Archive:  test_zip.zip
    testing: file_smaller_than_4g     OK
No errors detected in test_zip.zip for the 1 file tested.
```