### PR TITLE
crc_i386.S: mark stack as non-executable on ELF platforms

### DIFF
--- a/crc_i386.S
+++ b/crc_i386.S
@@ -302,3 +302,7 @@ _crc32:                         /* ulg crc32(ulg crc, uch *buf, extent len) */
 #endif /* i386 || _i386 || _I386 || __i386 */
 
 #endif /* !USE_ZLIB && !CRC_TABLE_ONLY */
+
+#if defined(__ELF__) && defined(__linux__)
+               .section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Without the change binutils-2.39 flags the issue of executable stack due to missing explicit stack marking (usually inserted by gcc):

    cc -o unzip  -Lbzip2 unzip.o crc32.o crc_gcc.o ... -s
    ld: warning: crc_gcc.o: missing .note.GNU-stack section implies executable stack
    ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker

The change adds marking with define guards.