### PR TITLE
fix: unable to process windows zip64 file

### DIFF
--- a/process.c
+++ b/process.c
@@ -1279,7 +1279,7 @@ static int find_ecrec64(__G__ searchlen)         /* return PK-class error */
     fprintf(stdout,"\nnumber of disks (ECR) %u, (ECLOC64) %lu\n",
             G.ecrec.number_this_disk, ecloc64_total_disks); fflush(stdout);
 #endif
-    if ((G.ecrec.number_this_disk != 0xFFFF) &&
+    if ((G.ecrec.number_this_disk != 0xFFFF) && ecloc64_total_disks &&
         (G.ecrec.number_this_disk != ecloc64_total_disks - 1)) {
       /* Note: For some unknown reason, the developers at PKWARE decided to
          store the "zip64 total disks" value as a counter starting from 1,


### PR DESCRIPTION
Issue is big onedrive archives from fail on extract because of faulty zip creator. This fix works tolerates the widespread faulty zip64 creation from redmond.

Closes: https://sourceforge.net/p/infozip/bugs/42/
Closes: https://bugs.gentoo.org/661100